### PR TITLE
Hyperlink DOI to preferred resolver

### DIFF
--- a/Chapter_1/Fig_1_2.m
+++ b/Chapter_1/Fig_1_2.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_2/Fig_2_1.m
+++ b/Chapter_2/Fig_2_1.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_2/Fig_2_10.m
+++ b/Chapter_2/Fig_2_10.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_2/Fig_2_11.m
+++ b/Chapter_2/Fig_2_11.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_2/Fig_2_12ac.m
+++ b/Chapter_2/Fig_2_12ac.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_2/Fig_2_12bd.m
+++ b/Chapter_2/Fig_2_12bd.m
@@ -4,7 +4,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_2/Fig_2_13.m
+++ b/Chapter_2/Fig_2_13.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_2/Fig_2_2.m
+++ b/Chapter_2/Fig_2_2.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_2/Fig_2_3a.m
+++ b/Chapter_2/Fig_2_3a.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_2/Fig_2_3b.m
+++ b/Chapter_2/Fig_2_3b.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_2/Fig_2_4.m
+++ b/Chapter_2/Fig_2_4.m
@@ -4,7 +4,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_2/Fig_2_6.m
+++ b/Chapter_2/Fig_2_6.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_2/Fig_2_7.m
+++ b/Chapter_2/Fig_2_7.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_2/Fig_2_8a.m
+++ b/Chapter_2/Fig_2_8a.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_2/Fig_2_8b.m
+++ b/Chapter_2/Fig_2_8b.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_2/Fig_2_9.m
+++ b/Chapter_2/Fig_2_9.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_3/Fig_3_11a.m
+++ b/Chapter_3/Fig_3_11a.m
@@ -4,7 +4,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_3/Fig_3_11b.m
+++ b/Chapter_3/Fig_3_11b.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_3/Fig_3_14.m
+++ b/Chapter_3/Fig_3_14.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_3/Fig_3_16.m
+++ b/Chapter_3/Fig_3_16.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_3/Fig_3_17.m
+++ b/Chapter_3/Fig_3_17.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_3/Fig_3_18a.m
+++ b/Chapter_3/Fig_3_18a.m
@@ -4,7 +4,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_3/Fig_3_18b.m
+++ b/Chapter_3/Fig_3_18b.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_3/Fig_3_19.m
+++ b/Chapter_3/Fig_3_19.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_3/Fig_3_2.m
+++ b/Chapter_3/Fig_3_2.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_3/Fig_3_21.m
+++ b/Chapter_3/Fig_3_21.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_3/Fig_3_22.m
+++ b/Chapter_3/Fig_3_22.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_3/Fig_3_23.m
+++ b/Chapter_3/Fig_3_23.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_3/Fig_3_24.m
+++ b/Chapter_3/Fig_3_24.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_3/Fig_3_25.m
+++ b/Chapter_3/Fig_3_25.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_3/Fig_3_26_Fig_3_27.m
+++ b/Chapter_3/Fig_3_26_Fig_3_27.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_3/Fig_3_3.m
+++ b/Chapter_3/Fig_3_3.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_3/Fig_3_30a_Fig_3_32a.m
+++ b/Chapter_3/Fig_3_30a_Fig_3_32a.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_3/Fig_3_30b.m
+++ b/Chapter_3/Fig_3_30b.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_3/Fig_3_32b.m
+++ b/Chapter_3/Fig_3_32b.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_3/Fig_3_5a.m
+++ b/Chapter_3/Fig_3_5a.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_3/Fig_3_5b.m
+++ b/Chapter_3/Fig_3_5b.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_3/Fig_3_6.m
+++ b/Chapter_3/Fig_3_6.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_3/Fig_3_8.m
+++ b/Chapter_3/Fig_3_8.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_3/Fig_3_9.m
+++ b/Chapter_3/Fig_3_9.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_4/Fig_4_11.m
+++ b/Chapter_4/Fig_4_11.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_13.m
+++ b/Chapter_4/Fig_4_13.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_14.m
+++ b/Chapter_4/Fig_4_14.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_15.m
+++ b/Chapter_4/Fig_4_15.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_16.m
+++ b/Chapter_4/Fig_4_16.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_17.m
+++ b/Chapter_4/Fig_4_17.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_18.m
+++ b/Chapter_4/Fig_4_18.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_19ace.m
+++ b/Chapter_4/Fig_4_19ace.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_19bdf.m
+++ b/Chapter_4/Fig_4_19bdf.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_20ac.m
+++ b/Chapter_4/Fig_4_20ac.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_20bd.m
+++ b/Chapter_4/Fig_4_20bd.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_23.m
+++ b/Chapter_4/Fig_4_23.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_24.m
+++ b/Chapter_4/Fig_4_24.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_25.m
+++ b/Chapter_4/Fig_4_25.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_26.m
+++ b/Chapter_4/Fig_4_26.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_30.m
+++ b/Chapter_4/Fig_4_30.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_32.m
+++ b/Chapter_4/Fig_4_32.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_33a.m
+++ b/Chapter_4/Fig_4_33a.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_33b.m
+++ b/Chapter_4/Fig_4_33b.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_34.m
+++ b/Chapter_4/Fig_4_34.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_35.m
+++ b/Chapter_4/Fig_4_35.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_36.m
+++ b/Chapter_4/Fig_4_36.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_37_Fig_4_38_Fig_4_40.m
+++ b/Chapter_4/Fig_4_37_Fig_4_38_Fig_4_40.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_39.m
+++ b/Chapter_4/Fig_4_39.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_4.m
+++ b/Chapter_4/Fig_4_4.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_41.m
+++ b/Chapter_4/Fig_4_41.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_42.m
+++ b/Chapter_4/Fig_4_42.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_6.m
+++ b/Chapter_4/Fig_4_6.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_4/Fig_4_7_Fig_4_9.m
+++ b/Chapter_4/Fig_4_7_Fig_4_9.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_11.m
+++ b/Chapter_5/Fig_5_11.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_5/Fig_5_12_Fig_5_13.m
+++ b/Chapter_5/Fig_5_12_Fig_5_13.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_15.m
+++ b/Chapter_5/Fig_5_15.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_16a.m
+++ b/Chapter_5/Fig_5_16a.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_16b.m
+++ b/Chapter_5/Fig_5_16b.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_18.m
+++ b/Chapter_5/Fig_5_18.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_20.m
+++ b/Chapter_5/Fig_5_20.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_21.m
+++ b/Chapter_5/Fig_5_21.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_22.m
+++ b/Chapter_5/Fig_5_22.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_23.m
+++ b/Chapter_5/Fig_5_23.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_24_Fig_5_25.m
+++ b/Chapter_5/Fig_5_24_Fig_5_25.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_26.m
+++ b/Chapter_5/Fig_5_26.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_28.m
+++ b/Chapter_5/Fig_5_28.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_29.m
+++ b/Chapter_5/Fig_5_29.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_30a.m
+++ b/Chapter_5/Fig_5_30a.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_30b.m
+++ b/Chapter_5/Fig_5_30b.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_31_Fig_5_32b_Fig_33b.m
+++ b/Chapter_5/Fig_5_31_Fig_5_32b_Fig_33b.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_32a.m
+++ b/Chapter_5/Fig_5_32a.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_33a.m
+++ b/Chapter_5/Fig_5_33a.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_34.m
+++ b/Chapter_5/Fig_5_34.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_37_Fig_5_38.m
+++ b/Chapter_5/Fig_5_37_Fig_5_38.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_40.m
+++ b/Chapter_5/Fig_5_40.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_41.m
+++ b/Chapter_5/Fig_5_41.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_42ace.m
+++ b/Chapter_5/Fig_5_42ace.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_42bdf.m
+++ b/Chapter_5/Fig_5_42bdf.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_43ac.m
+++ b/Chapter_5/Fig_5_43ac.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_43bd.m
+++ b/Chapter_5/Fig_5_43bd.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_45.m
+++ b/Chapter_5/Fig_5_45.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_46.m
+++ b/Chapter_5/Fig_5_46.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_47.m
+++ b/Chapter_5/Fig_5_47.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_48.m
+++ b/Chapter_5/Fig_5_48.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_49a.m
+++ b/Chapter_5/Fig_5_49a.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_49b.m
+++ b/Chapter_5/Fig_5_49b.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_4_Fig_5_8.m
+++ b/Chapter_5/Fig_5_4_Fig_5_8.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_50a.m
+++ b/Chapter_5/Fig_5_50a.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_50b_Fig_5_51_Fig_5_53.m
+++ b/Chapter_5/Fig_5_50b_Fig_5_51_Fig_5_53.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_52a.m
+++ b/Chapter_5/Fig_5_52a.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_52b.m
+++ b/Chapter_5/Fig_5_52b.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_54a.m
+++ b/Chapter_5/Fig_5_54a.m
@@ -4,7 +4,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_54bc_Fig_55a.m
+++ b/Chapter_5/Fig_5_54bc_Fig_55a.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_55b.m
+++ b/Chapter_5/Fig_5_55b.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_57a.m
+++ b/Chapter_5/Fig_5_57a.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_57b.m
+++ b/Chapter_5/Fig_5_57b.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_57c.m
+++ b/Chapter_5/Fig_5_57c.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_6.m
+++ b/Chapter_5/Fig_5_6.m
@@ -3,7 +3,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Chapter_5/Fig_5_7.m
+++ b/Chapter_5/Fig_5_7.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Chapter_5/Fig_5_9_Fig_5_10.m
+++ b/Chapter_5/Fig_5_9_Fig_5_10.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Common/fftx/fftx.m
+++ b/Common/fftx/fftx.m
@@ -7,7 +7,7 @@ function [ out ] = fftx( varargin )
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Common/fftx/ifftx.m
+++ b/Common/fftx/ifftx.m
@@ -7,7 +7,7 @@ function [ out ] = ifftx( varargin )
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Common/misc/Chi_extended_source.m
+++ b/Common/misc/Chi_extended_source.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Common/misc/HOA25D_modal_filter.m
+++ b/Common/misc/HOA25D_modal_filter.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Common/misc/Lambda_projection.m
+++ b/Common/misc/Lambda_projection.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Common/misc/Psi_extended_source.m
+++ b/Common/misc/Psi_extended_source.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Common/misc/Psi_projection.m
+++ b/Common/misc/Psi_projection.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Common/misc/mathring_w.m
+++ b/Common/misc/mathring_w.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Common/misc/point_source.m
+++ b/Common/misc/point_source.m
@@ -9,7 +9,7 @@ function [ S ] = point_source( x, y, x_s, y_s, z_s, k )
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Common/misc/transfer_function_circular_array_single_position.m
+++ b/Common/misc/transfer_function_circular_array_single_position.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Common/misc/transfer_function_linear_array_single_position.m
+++ b/Common/misc/transfer_function_linear_array_single_position.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Common/plot_tools/fig_size.m
+++ b/Common/plot_tools/fig_size.m
@@ -7,7 +7,7 @@ function h = fig_size( x, y );
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Common/plot_tools/graph_defaults.m
+++ b/Common/plot_tools/graph_defaults.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Common/plot_tools/revert_colormap.m
+++ b/Common/plot_tools/revert_colormap.m
@@ -4,7 +4,7 @@ function [] = revert_colormap()
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Common/plot_tools/turn_imagesc.m
+++ b/Common/plot_tools/turn_imagesc.m
@@ -4,7 +4,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Common/spherical/asslegendre.m
+++ b/Common/spherical/asslegendre.m
@@ -6,7 +6,7 @@ function [ Lnm ] = asslegendre( n, m, arg )
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Common/spherical/e_symbol.m
+++ b/Common/spherical/e_symbol.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Common/spherical/general_translation_coefficients.m
+++ b/Common/spherical/general_translation_coefficients.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Common/spherical/sectorial_translation_coefficients.m
+++ b/Common/spherical/sectorial_translation_coefficients.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %

--- a/Common/spherical/sphbesselh.m
+++ b/Common/spherical/sphbesselh.m
@@ -7,7 +7,7 @@ function [ out ] = sphbesselh( nu, k, z )
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Common/spherical/sphbesseli.m
+++ b/Common/spherical/sphbesseli.m
@@ -8,7 +8,7 @@ function [ out ] = sphbesseli( nu, z )
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Common/spherical/sphbesselj.m
+++ b/Common/spherical/sphbesselj.m
@@ -7,7 +7,7 @@ function [ out ] = sphbesselj( nu, z )
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Common/spherical/sphbesselk.m
+++ b/Common/spherical/sphbesselk.m
@@ -8,7 +8,7 @@ function [ out ] = sphbesselk( nu, z )
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Common/spherical/sphbessely.m
+++ b/Common/spherical/sphbessely.m
@@ -8,7 +8,7 @@ function [ out ] = sphbessely( nu, z )
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Common/spherical/sphharm.m
+++ b/Common/spherical/sphharm.m
@@ -15,7 +15,7 @@ function [ Ynm ] = sphharm( n, m, beta, alpha );
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  % 

--- a/Common/spherical/zonal_translation_coefficients.m
+++ b/Common/spherical/zonal_translation_coefficients.m
@@ -2,7 +2,7 @@
 % This work is supplementary material for the book                        %
 %                                                                         %
 % Jens Ahrens, Analytic Methods of Sound Field Synthesis, Springer-Verlag %
-% Berlin Heidelberg, 2012, http://dx.doi.org/10.1007/978-3-642-25743-8    %
+% Berlin Heidelberg, 2012, https://doi.org/10.1007/978-3-642-25743-8      %
 %                                                                         %
 % It has been downloaded from http://soundfieldsynthesis.org and is       %
 % licensed under a Creative Commons Attribution-NonCommercial-ShareAlike  %


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!